### PR TITLE
Bug#600 qkt deepcopies kernel internally, fails with runtime primitives

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -138,15 +138,8 @@ numfig_format = {"table": "Table %s"}
 
 translations_list = [
     ("en", "English"),
-    ("bn_BN", "Bengali"),
-    ("fr_FR", "French"),
-    ("hi_IN", "Hindi"),
     ("ja_JP", "Japanese"),
-    ("ko_KR", "Korean"),
-    ("ru_RU", "Russian"),
     ("es_UN", "Spanish"),
-    ("ta_IN", "Tamil"),
-    ("tr_TR", "Turkish"),
 ]
 language = "en"
 

--- a/qiskit_machine_learning/kernels/algorithms/quantum_kernel_trainer.py
+++ b/qiskit_machine_learning/kernels/algorithms/quantum_kernel_trainer.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -13,7 +13,6 @@
 """Quantum Kernel Trainer"""
 from __future__ import annotations
 
-import copy
 from functools import partial
 from typing import Sequence
 
@@ -198,12 +197,16 @@ class QuantumKernelTrainer:
             msg = "Quantum kernel cannot be fit because there are no user parameters specified."
             raise ValueError(msg)
 
-        # Bind inputs to objective function
-        output_kernel = copy.deepcopy(self._quantum_kernel)
-
         # Randomly initialize the initial point if one was not passed
         if self._initial_point is None:
             self._initial_point = algorithm_globals.random.random(num_params)
+
+        # Bind inputs to objective function
+        output_kernel = type(self._quantum_kernel)(
+            feature_map=self._quantum_kernel.feature_map,
+            training_parameters=self._quantum_kernel.training_parameters,
+        )
+        output_kernel.assign_training_parameters(parameter_values=self.initial_point)
 
         # Perform kernel optimization
         loss_function = partial(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Bug#600: 'qkt deepcopies kernel internally, fails with runtime primitives'

The quantum kernel trainer QKT.fit() method used copy.deepcopy to create an optimised results kernel to be returned instead of changing the input kernel. The deepcopy would throw an error when using qiskit-ibm-runtime primitives and ibm-q services, including simulators. Deepcopy has been replaced by initialising a new class instance of the training kernel and manually assigning parameters. This change passed testing and works with qiskit-ibm-runtime primitives, as well as qiskit-aer and qiskit primitives.


### Details and comments
No additional documents needed as nothing user side has changed nor functionality added, internal change only.