### PR TITLE
Made fidelity_statevector_kernel picklable

### DIFF
--- a/qiskit_machine_learning/kernels/fidelity_statevector_kernel.py
+++ b/qiskit_machine_learning/kernels/fidelity_statevector_kernel.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023.
+# (C) Copyright IBM 2023, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -97,7 +97,7 @@ class FidelityStatevectorKernel(BaseKernel):
         self._auto_clear_cache = auto_clear_cache
         self._shots = shots
         self._enforce_psd = enforce_psd
-
+        self.cache_size = cache_size
         # Create the statevector cache at the instance level.
         self._get_statevector = lru_cache(maxsize=cache_size)(self._get_statevector_)
 
@@ -160,3 +160,12 @@ class FidelityStatevectorKernel(BaseKernel):
         """Clear the statevector cache."""
         # pylint: disable=no-member
         self._get_statevector.cache_clear()
+
+    def __getstate__(self) -> dict:
+        picklable_kernel = dict(self.__dict__)
+        picklable_kernel["_get_statevector"] = None
+        return picklable_kernel
+
+    def __setstate__(self, unpickled_kernel):
+        self.__dict__ = unpickled_kernel
+        self._get_statevector = lru_cache(maxsize=self.cache_size)(self._get_statevector_)

--- a/releasenotes/notes/fix-fid_statevector_kernel-pickling-b7fa2b13a15ec9c6.yaml
+++ b/releasenotes/notes/fix-fid_statevector_kernel-pickling-b7fa2b13a15ec9c6.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed bug where fidelity_statevector_kernel could not be pickled. This was due to the functools 
+    lru cache having a known error with pickling. Added __getstate__ and __setstate__ attributes
+    to deal with the cache when pickling by setting it to None type then re-initialising when
+    unpickled. Added a self.cache_size param for unpickling process.
+


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixed bug #5 whereby fidelity statevector kernel can't be picked due to known problem with pickling functools lru_cache. Original bug: https://github.com/qiskit-community/qiskit-machine-learning/issues/607

### Details and comments
Added a new param to store cache size and a custom __getstate__  and __setstate__ to handle removing/re-initliasing the lru cache during pickle/unpickling respectively. 

